### PR TITLE
Spaces can now safely exist in file path, Exit after --help

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The script searches the `Info.plist` in the current path and increases the build
 
 ```bash
 Usage:
-xcibversion [--interactive|-i] [--build=SPECIFIC_BUILD] [--path=PATH][--dry-run]
+xcibversion [--interactive|-i] [--build=SPECIFIC_BUILD] [--path=PATH] [--dry-run]
 ```
 
 ## Interactive

--- a/xcibversion
+++ b/xcibversion
@@ -48,9 +48,13 @@ else
 fi
 }
 
-for file in `find ${WORKDIR} -name "Info.plist"` ; do
-  value=`plutil -extract CFBundleVersion xml1 -o - $file`
+
+find $WORKDIR -name "Info.plist" -print0 |
+while IFS= read -r -d '' file; do
+
+  value=`plutil -extract CFBundleVersion xml1 -o - "$file"`
   build=`echo ${value} | xmllint --xpath "//string/text()" -`
+  
   re='^[0-9]+$'
   if [[ $build =~ $re ]] ; then
     if [ ! -z "${SPECIFIC_BUILD}" ] ; then
@@ -58,20 +62,20 @@ for file in `find ${WORKDIR} -name "Info.plist"` ; do
     else
       new_build=$((build + 1))
     fi
-    echo "build: ${build} New: ${new_build}"
+    echo "> current: ${build} new: ${new_build}"
     if [ ! -z "${INTERACTIVE}" ] ; then
       while true; do
-        read -p "Update File: ${file} - fromm build:${build} to: ${new_build}?[y|n|stop] " answer
+        read -p "Update File: ${file} - from build:${build} to: ${new_build}? [y|n|stop] " answer
         case ${answer:0:1} in
-          Y|y ) _execute "plutil -replace CFBundleVersion -string "${new_build}" ${file}" ; break;;
+          Y|y ) _execute "plutil -replace CFBundleVersion -string \"${new_build}\" \"${file}\"" ; break;;
           N|n ) break;;
           S|s ) exit;;
           * ) echo "Please answer yes or no.";;
         esac
       done
     else
-      _execute "plutil -replace CFBundleVersion -string "${new_build}" ${file}"
-      echo "Updated File: ${file} - fromm build:${build} to: ${new_build}" 
+      _execute "plutil -replace CFBundleVersion -string \"${new_build}\" \"${file}\""
+      echo "Updated File: ${file} - from build:${build} to: ${new_build}" 
     fi
   fi
 done

--- a/xcibversion
+++ b/xcibversion
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 
-USAGE="Usage:\n${0##*/} [--interactive|-i] [--build=SPECIFIC_BUILD] [--path=PATH][--dry-run]"
+USAGE="Usage:\n${0##*/} [--interactive|-i] [--build=SPECIFIC_BUILD] [--path=PATH] [--dry-run]"
 arguments=""
 WORKDIR="."
 for i in "$@"
 do
   case $i in
     --help)
-      printf "${USAGE}"
+      printf "${USAGE}\n"
+      exit
       ;;
     -i|--interactive)
       INTERACTIVE=1


### PR DESCRIPTION
Thanks for your blog post! It played a huge role in getting our CI system running and pumping our local iOS builds up to App Store Connect.

In setting everything up, I ran into a few issues:
* we had some paths that had spaces in them and it was causing issues with the script. I put a fix in there based off this [SO conversation](https://askubuntu.com/questions/343727/filenames-with-spaces-breaking-for-loop-find-command).
* if you called `--help`; it would print the usage and continue to process the current directory.

I also put a few formatting changes and typo fixes in here. Hope this is useful for you!