### PR TITLE
Makes path argument mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you want to read a more detailed explanation check the article here:
 
 ```bash
 Usage:
-xcibversion [--interactive|-i] [--build=SPECIFIC_BUILD] [--path=PATH] [--dry-run]
+xcibversion --path=PATH [--interactive|-i] [--build=SPECIFIC_BUILD] [--dry-run]
 ```
 
 ## Interactive
@@ -26,13 +26,13 @@ Using the `--build` argument, you can specify the build number the replace the c
 For example:
 
 ```bash
-$ ./xcibversion --build=15  --path=./myProject/
+$ ./xcibversion --path=./myProject/ --build=15
 ```
 
 
 ## Define the path to search for `Info.plist` files
 
-If `--path` argument is used the script will search in that path for `Info.plist` files for processing.
+The `--path` argument is mandatory. The script will search in that path for `Info.plist` files for processing.
 
 ## Dry run
 

--- a/xcibversion
+++ b/xcibversion
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
-USAGE="Usage:\n${0##*/} [--interactive|-i] [--build=SPECIFIC_BUILD] [--path=PATH] [--dry-run]"
+USAGE="Usage:\n${0##*/} --path=PATH [--interactive|-i] [--build=SPECIFIC_BUILD] [--dry-run]"
 arguments=""
-WORKDIR="."
 for i in "$@"
 do
   case $i in
@@ -36,6 +35,10 @@ do
       ;;
   esac
 done
+if [ -z ${WORKDIR} ] ; then
+  printf "ERROR: Missing path.\n\n${USAGE}\n"
+  exit 1
+fi
 if [ ! -z "${DEBUG}" ] ; then
   echo "INTERACTIVE = ${INTERACTIVE}"
   echo "SPECIFIC_BUILD = ${SPECIFIC_BUILD}"


### PR DESCRIPTION
As discussed on https://github.com/rderik/xcibversion/issues/2

Making the `path` argument mandatory as a safety measure.